### PR TITLE
Resolved warnings in driver.

### DIFF
--- a/Source/CoreData/Driver.swift
+++ b/Source/CoreData/Driver.swift
@@ -373,13 +373,13 @@ class Driver: NSObject {
         } else {
             let kNSManagedObjectContextThreadKey = "kNSManagedObjectContextThreadKey"
             let threadDictionary = NSThread.currentThread().threadDictionary
-            if let context = threadDictionary?[kNSManagedObjectContextThreadKey] as? NSManagedObjectContext {
+            if let context = threadDictionary[kNSManagedObjectContextThreadKey] as? NSManagedObjectContext {
                 return context
             } else {
                 let context = NSManagedObjectContext(concurrencyType: NSManagedObjectContextConcurrencyType.PrivateQueueConcurrencyType)
                 context.parentContext = self.coreDataStack.defaultManagedObjectContext
                 context.mergePolicy = NSOverwriteMergePolicy
-                threadDictionary?.setObject(context, forKey: kNSManagedObjectContextThreadKey)
+                threadDictionary.setObject(context, forKey: kNSManagedObjectContextThreadKey)
                 return context
             }
         }


### PR DESCRIPTION
Please check your framework with Xcode 6.1.1, where it does not compile. This change appears to fix it. Please let me know if it is short-sighted in some way.